### PR TITLE
Add event scheduling for activity sessions

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,8 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- View upcoming scheduled sessions for each activity
+- Advisor session management via API (create, edit, delete)
 
 ## Getting Started
 
@@ -31,6 +33,10 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| GET    | `/activities/{activity_name}/sessions`                            | Get all scheduled sessions for an activity                          |
+| POST   | `/advisor/activities/{activity_name}/sessions`                    | Create a new scheduled session for an activity                      |
+| PUT    | `/advisor/activities/{activity_name}/sessions/{session_id}`       | Update an existing scheduled session                                |
+| DELETE | `/advisor/activities/{activity_name}/sessions/{session_id}`       | Delete a scheduled session                                          |
 
 ## Data Model
 
@@ -39,7 +45,13 @@ The application uses a simple data model with meaningful identifiers:
 1. **Activities** - Uses activity name as identifier:
 
    - Description
-   - Schedule
+   - Schedule (legacy free-text field)
+   - Structured sessions list with:
+     - Session id
+     - Date (`YYYY-MM-DD`)
+     - Start time (`HH:MM`)
+     - End time (`HH:MM`)
+     - Optional location
    - Maximum number of participants allowed
    - List of student emails who are signed up
 

--- a/src/app.py
+++ b/src/app.py
@@ -1,15 +1,18 @@
-"""
-High School Management System API
+"""High School Management System API.
 
-A super simple FastAPI application that allows students to view and sign up
+A simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
 import os
+from datetime import datetime
 from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,61 +22,173 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
+class SessionCreate(BaseModel):
+    date: str = Field(..., description="Session date in YYYY-MM-DD format")
+    start_time: str = Field(..., description="Start time in HH:MM (24-hour) format")
+    end_time: str = Field(..., description="End time in HH:MM (24-hour) format")
+    location: Optional[str] = Field(default=None, description="Optional session location")
+
+
+class SessionUpdate(BaseModel):
+    date: Optional[str] = Field(default=None, description="Session date in YYYY-MM-DD format")
+    start_time: Optional[str] = Field(default=None, description="Start time in HH:MM (24-hour) format")
+    end_time: Optional[str] = Field(default=None, description="End time in HH:MM (24-hour) format")
+    location: Optional[str] = Field(default=None, description="Optional session location")
+
+
+session_id_counter = 1
+
+
+def _validate_date(date_str: str) -> None:
+    try:
+        datetime.strptime(date_str, "%Y-%m-%d")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="date must be in YYYY-MM-DD format") from exc
+
+
+def _validate_time(time_str: str) -> None:
+    try:
+        datetime.strptime(time_str, "%H:%M")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="time must be in HH:MM format") from exc
+
+
+def _validate_session_window(date_str: str, start_time: str, end_time: str) -> None:
+    _validate_date(date_str)
+    _validate_time(start_time)
+    _validate_time(end_time)
+
+    start_dt = datetime.strptime(f"{date_str} {start_time}", "%Y-%m-%d %H:%M")
+    end_dt = datetime.strptime(f"{date_str} {end_time}", "%Y-%m-%d %H:%M")
+    if end_dt <= start_dt:
+        raise HTTPException(status_code=400, detail="end_time must be later than start_time")
+
+
+def _create_session(date_str: str, start_time: str, end_time: str, location: Optional[str] = None) -> dict:
+    global session_id_counter
+    _validate_session_window(date_str, start_time, end_time)
+
+    session = {
+        "id": session_id_counter,
+        "date": date_str,
+        "start_time": start_time,
+        "end_time": end_time,
+        "location": location,
+    }
+    session_id_counter += 1
+    return session
+
+
+def _session_start(session: dict) -> datetime:
+    return datetime.strptime(f"{session['date']} {session['start_time']}", "%Y-%m-%d %H:%M")
+
+
+def _sorted_sessions(sessions: list[dict]) -> list[dict]:
+    return sorted(sessions, key=_session_start)
+
+
+def _upcoming_sessions(sessions: list[dict]) -> list[dict]:
+    now = datetime.now()
+    return [session for session in _sorted_sessions(sessions) if _session_start(session) >= now]
+
+
+def _get_activity_or_404(activity_name: str) -> dict:
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    return activities[activity_name]
+
+
 # In-memory activity database
 activities = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+        "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
+        "sessions": [
+            _create_session("2026-03-27", "15:30", "17:00", "Room 201"),
+            _create_session("2026-04-03", "15:30", "17:00", "Room 201"),
+        ],
     },
     "Programming Class": {
         "description": "Learn programming fundamentals and build software projects",
         "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
         "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+        "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
+        "sessions": [
+            _create_session("2026-03-24", "15:30", "16:30", "Lab A"),
+            _create_session("2026-03-26", "15:30", "16:30", "Lab A"),
+        ],
     },
     "Gym Class": {
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+        "participants": ["john@mergington.edu", "olivia@mergington.edu"],
+        "sessions": [
+            _create_session("2026-03-23", "14:00", "15:00", "Main Gym"),
+            _create_session("2026-03-25", "14:00", "15:00", "Main Gym"),
+        ],
     },
     "Soccer Team": {
         "description": "Join the school soccer team and compete in matches",
         "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
         "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"],
+        "sessions": [
+            _create_session("2026-03-24", "16:00", "17:30", "Soccer Field"),
+            _create_session("2026-03-26", "16:00", "17:30", "Soccer Field"),
+        ],
     },
     "Basketball Team": {
         "description": "Practice and play basketball with the school team",
         "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"],
+        "sessions": [
+            _create_session("2026-03-25", "15:30", "17:00", "West Court"),
+            _create_session("2026-03-27", "15:30", "17:00", "West Court"),
+        ],
     },
     "Art Club": {
         "description": "Explore your creativity through painting and drawing",
         "schedule": "Thursdays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
+        "sessions": [
+            _create_session("2026-03-26", "15:30", "17:00", "Art Studio"),
+            _create_session("2026-04-02", "15:30", "17:00", "Art Studio"),
+        ],
     },
     "Drama Club": {
         "description": "Act, direct, and produce plays and performances",
         "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
         "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
+        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
+        "sessions": [
+            _create_session("2026-03-23", "16:00", "17:30", "Auditorium"),
+            _create_session("2026-03-25", "16:00", "17:30", "Auditorium"),
+        ],
     },
     "Math Club": {
         "description": "Solve challenging problems and participate in math competitions",
         "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
         "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
+        "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
+        "sessions": [
+            _create_session("2026-03-24", "15:30", "16:30", "Room 105"),
+            _create_session("2026-03-31", "15:30", "16:30", "Room 105"),
+        ],
     },
     "Debate Team": {
         "description": "Develop public speaking and argumentation skills",
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+        "sessions": [
+            _create_session("2026-03-27", "16:00", "17:30", "Debate Hall"),
+            _create_session("2026-04-03", "16:00", "17:30", "Debate Hall"),
+        ],
     }
 }
 
@@ -85,18 +200,96 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    return {
+        name: {
+            **details,
+            "sessions": _sorted_sessions(details.get("sessions", [])),
+            "upcoming_sessions": _upcoming_sessions(details.get("sessions", [])),
+        }
+        for name, details in activities.items()
+    }
+
+
+@app.get("/activities/{activity_name}/sessions")
+def get_activity_sessions(activity_name: str):
+    """Get all scheduled sessions for an activity."""
+    activity = _get_activity_or_404(activity_name)
+    return {
+        "activity": activity_name,
+        "sessions": _sorted_sessions(activity.get("sessions", [])),
+    }
+
+
+@app.post("/advisor/activities/{activity_name}/sessions")
+def create_activity_session(activity_name: str, session: SessionCreate):
+    """Advisor endpoint for creating a new scheduled session."""
+    activity = _get_activity_or_404(activity_name)
+    new_session = _create_session(
+        session.date,
+        session.start_time,
+        session.end_time,
+        session.location,
+    )
+    activity.setdefault("sessions", []).append(new_session)
+    return {
+        "message": f"Created session for {activity_name}",
+        "session": new_session,
+    }
+
+
+@app.put("/advisor/activities/{activity_name}/sessions/{session_id}")
+def update_activity_session(activity_name: str, session_id: int, session_update: SessionUpdate):
+    """Advisor endpoint for updating an existing scheduled session."""
+    activity = _get_activity_or_404(activity_name)
+    sessions = activity.get("sessions", [])
+
+    for session in sessions:
+        if session["id"] != session_id:
+            continue
+
+        if session_update.date is not None:
+            _validate_date(session_update.date)
+            session["date"] = session_update.date
+        if session_update.start_time is not None:
+            _validate_time(session_update.start_time)
+            session["start_time"] = session_update.start_time
+        if session_update.end_time is not None:
+            _validate_time(session_update.end_time)
+            session["end_time"] = session_update.end_time
+        if session_update.location is not None:
+            session["location"] = session_update.location
+
+        _validate_session_window(session["date"], session["start_time"], session["end_time"])
+
+        return {
+            "message": f"Updated session {session_id} for {activity_name}",
+            "session": session,
+        }
+
+    raise HTTPException(status_code=404, detail="Session not found")
+
+
+@app.delete("/advisor/activities/{activity_name}/sessions/{session_id}")
+def delete_activity_session(activity_name: str, session_id: int):
+    """Advisor endpoint for deleting a scheduled session."""
+    activity = _get_activity_or_404(activity_name)
+    sessions = activity.get("sessions", [])
+
+    for index, session in enumerate(sessions):
+        if session["id"] == session_id:
+            removed_session = sessions.pop(index)
+            return {
+                "message": f"Deleted session {session_id} from {activity_name}",
+                "session": removed_session,
+            }
+
+    raise HTTPException(status_code=404, detail="Session not found")
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
-    activity = activities[activity_name]
+    activity = _get_activity_or_404(activity_name)
 
     # Validate student is not already signed up
     if email in activity["participants"]:
@@ -113,12 +306,7 @@ def signup_for_activity(activity_name: str, email: str):
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
-    activity = activities[activity_name]
+    activity = _get_activity_or_404(activity_name)
 
     # Validate student is signed up
     if email not in activity["participants"]:

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,14 +4,132 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  const sessionActivitySelect = document.getElementById("session-activity");
+  const sessionForm = document.getElementById("session-form");
+  const sessionIdInput = document.getElementById("session-id");
+  const sessionDateInput = document.getElementById("session-date");
+  const sessionStartTimeInput = document.getElementById("session-start-time");
+  const sessionEndTimeInput = document.getElementById("session-end-time");
+  const sessionLocationInput = document.getElementById("session-location");
+  const sessionSubmitBtn = document.getElementById("session-submit-btn");
+  const sessionCancelBtn = document.getElementById("session-cancel-btn");
+  const sessionMessageDiv = document.getElementById("session-message");
+  const advisorSessionsList = document.getElementById("advisor-sessions-list");
+
+  let activitiesCache = {};
+
+  function showMessage(target, text, type) {
+    target.textContent = text;
+    target.className = type;
+    target.classList.remove("hidden");
+
+    setTimeout(() => {
+      target.classList.add("hidden");
+    }, 5000);
+  }
+
+  function formatSessionLabel(session) {
+    const locationPart = session.location ? ` | ${session.location}` : "";
+    return `${session.date} | ${session.start_time} - ${session.end_time}${locationPart}`;
+  }
+
+  function buildUpcomingSessionsHTML(details) {
+    const upcoming = details.upcoming_sessions || [];
+    if (!upcoming.length) {
+      return `<p><strong>Upcoming sessions:</strong> <em>No upcoming sessions scheduled</em></p>`;
+    }
+
+    return `
+      <div class="sessions-section">
+        <h5>Upcoming sessions</h5>
+        <ul class="session-list">
+          ${upcoming
+            .map((session) => `<li>${formatSessionLabel(session)}</li>`)
+            .join("")}
+        </ul>
+      </div>
+    `;
+  }
+
+  function populateActivityDropdowns(activities) {
+    activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
+    sessionActivitySelect.innerHTML =
+      '<option value="">-- Select an activity --</option>';
+
+    Object.keys(activities).forEach((name) => {
+      const studentOption = document.createElement("option");
+      studentOption.value = name;
+      studentOption.textContent = name;
+      activitySelect.appendChild(studentOption);
+
+      const advisorOption = document.createElement("option");
+      advisorOption.value = name;
+      advisorOption.textContent = name;
+      sessionActivitySelect.appendChild(advisorOption);
+    });
+  }
+
+  function resetSessionForm() {
+    sessionIdInput.value = "";
+    sessionForm.reset();
+    sessionSubmitBtn.textContent = "Create Session";
+    sessionCancelBtn.classList.add("hidden");
+  }
+
+  function populateAdvisorSessionList(activities) {
+    advisorSessionsList.innerHTML = "";
+
+    Object.entries(activities).forEach(([activityName, details]) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "advisor-activity-group";
+
+      const sessions = details.sessions || [];
+      const sessionsHtml = sessions.length
+        ? sessions
+            .map(
+              (session) => `
+                <li>
+                  <span>${formatSessionLabel(session)}</span>
+                  <div class="session-actions">
+                    <button class="session-edit-btn" data-activity="${activityName}" data-session-id="${session.id}">Edit</button>
+                    <button class="session-delete-btn" data-activity="${activityName}" data-session-id="${session.id}">Delete</button>
+                  </div>
+                </li>
+              `
+            )
+            .join("")
+        : "<li><em>No sessions yet</em></li>";
+
+      wrapper.innerHTML = `
+        <h5>${activityName}</h5>
+        <ul class="session-list advisor-session-list">
+          ${sessionsHtml}
+        </ul>
+      `;
+
+      advisorSessionsList.appendChild(wrapper);
+    });
+
+    document.querySelectorAll(".session-edit-btn").forEach((button) => {
+      button.addEventListener("click", handleEditSession);
+    });
+
+    document.querySelectorAll(".session-delete-btn").forEach((button) => {
+      button.addEventListener("click", handleDeleteSession);
+    });
+  }
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
       const response = await fetch("/activities");
       const activities = await response.json();
+      activitiesCache = activities;
 
       // Clear loading message
       activitiesList.innerHTML = "";
+
+      populateActivityDropdowns(activities);
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -41,6 +159,7 @@ document.addEventListener("DOMContentLoaded", () => {
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
+          ${buildUpcomingSessionsHTML(details)}
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
           <div class="participants-container">
             ${participantsHTML}
@@ -48,13 +167,9 @@ document.addEventListener("DOMContentLoaded", () => {
         `;
 
         activitiesList.appendChild(activityCard);
-
-        // Add option to select dropdown
-        const option = document.createElement("option");
-        option.value = name;
-        option.textContent = name;
-        activitySelect.appendChild(option);
       });
+
+      populateAdvisorSessionList(activities);
 
       // Add event listeners to delete buttons
       document.querySelectorAll(".delete-btn").forEach((button) => {
@@ -96,12 +211,11 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.className = "error";
       }
 
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
+      showMessage(
+        messageDiv,
+        response.ok ? result.message : result.detail || "An error occurred",
+        response.ok ? "success" : "error"
+      );
     } catch (error) {
       messageDiv.textContent = "Failed to unregister. Please try again.";
       messageDiv.className = "error";
@@ -136,22 +250,124 @@ document.addEventListener("DOMContentLoaded", () => {
 
         // Refresh activities list to show updated participants
         fetchActivities();
-      } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
       }
 
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
+      showMessage(
+        messageDiv,
+        response.ok ? result.message : result.detail || "An error occurred",
+        response.ok ? "success" : "error"
+      );
     } catch (error) {
       messageDiv.textContent = "Failed to sign up. Please try again.";
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  async function handleDeleteSession(event) {
+    const button = event.target;
+    const activity = button.getAttribute("data-activity");
+    const sessionId = button.getAttribute("data-session-id");
+
+    try {
+      const response = await fetch(
+        `/advisor/activities/${encodeURIComponent(activity)}/sessions/${sessionId}`,
+        {
+          method: "DELETE",
+        }
+      );
+      const result = await response.json();
+
+      showMessage(
+        sessionMessageDiv,
+        response.ok ? result.message : result.detail || "An error occurred",
+        response.ok ? "success" : "error"
+      );
+
+      if (response.ok) {
+        fetchActivities();
+      }
+    } catch (error) {
+      showMessage(sessionMessageDiv, "Failed to delete session.", "error");
+      console.error("Error deleting session:", error);
+    }
+  }
+
+  function handleEditSession(event) {
+    const button = event.target;
+    const activity = button.getAttribute("data-activity");
+    const sessionId = Number(button.getAttribute("data-session-id"));
+
+    const activityDetails = activitiesCache[activity];
+    if (!activityDetails) {
+      return;
+    }
+
+    const session = (activityDetails.sessions || []).find((item) => item.id === sessionId);
+    if (!session) {
+      return;
+    }
+
+    sessionActivitySelect.value = activity;
+    sessionIdInput.value = String(session.id);
+    sessionDateInput.value = session.date;
+    sessionStartTimeInput.value = session.start_time;
+    sessionEndTimeInput.value = session.end_time;
+    sessionLocationInput.value = session.location || "";
+
+    sessionSubmitBtn.textContent = "Update Session";
+    sessionCancelBtn.classList.remove("hidden");
+  }
+
+  sessionCancelBtn.addEventListener("click", () => {
+    resetSessionForm();
+  });
+
+  sessionForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const activity = sessionActivitySelect.value;
+    const sessionId = sessionIdInput.value;
+
+    const payload = {
+      date: sessionDateInput.value,
+      start_time: sessionStartTimeInput.value,
+      end_time: sessionEndTimeInput.value,
+      location: sessionLocationInput.value || null,
+    };
+
+    const isEditing = Boolean(sessionId);
+    const url = isEditing
+      ? `/advisor/activities/${encodeURIComponent(activity)}/sessions/${sessionId}`
+      : `/advisor/activities/${encodeURIComponent(activity)}/sessions`;
+
+    const method = isEditing ? "PUT" : "POST";
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const result = await response.json();
+
+      showMessage(
+        sessionMessageDiv,
+        response.ok ? result.message : result.detail || "An error occurred",
+        response.ok ? "success" : "error"
+      );
+
+      if (response.ok) {
+        resetSessionForm();
+        fetchActivities();
+      }
+    } catch (error) {
+      showMessage(sessionMessageDiv, "Failed to save session.", "error");
+      console.error("Error saving session:", error);
     }
   });
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -39,6 +39,50 @@
         </form>
         <div id="message" class="hidden"></div>
       </section>
+
+      <section id="session-management-container">
+        <h3>Advisor Session Management</h3>
+        <form id="session-form">
+          <input type="hidden" id="session-id" />
+          <div class="form-group">
+            <label for="session-activity">Activity:</label>
+            <select id="session-activity" required>
+              <option value="">-- Select an activity --</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="session-date">Date:</label>
+            <input type="date" id="session-date" required />
+          </div>
+          <div class="time-grid">
+            <div class="form-group">
+              <label for="session-start-time">Start time:</label>
+              <input type="time" id="session-start-time" required />
+            </div>
+            <div class="form-group">
+              <label for="session-end-time">End time:</label>
+              <input type="time" id="session-end-time" required />
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="session-location">Location (optional):</label>
+            <input type="text" id="session-location" placeholder="Room, court, field..." />
+          </div>
+          <div class="button-row">
+            <button type="submit" id="session-submit-btn">Create Session</button>
+            <button type="button" id="session-cancel-btn" class="secondary-btn hidden">Cancel Edit</button>
+          </div>
+        </form>
+
+        <div id="session-message" class="hidden"></div>
+
+        <div class="advisor-sessions-panel">
+          <h4>Existing Sessions</h4>
+          <div id="advisor-sessions-list">
+            <p>Loading sessions...</p>
+          </div>
+        </div>
+      </section>
     </main>
 
     <footer>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -87,6 +87,25 @@ section h3 {
   font-size: 16px;
 }
 
+.sessions-section {
+  margin-bottom: 12px;
+}
+
+.sessions-section h5 {
+  margin-bottom: 6px;
+  color: #1a237e;
+  font-size: 15px;
+}
+
+.session-list {
+  list-style: none;
+  padding-left: 5px;
+}
+
+.session-list li {
+  padding: 4px 0;
+}
+
 .participants-section ul {
   list-style-type: none;
   padding-left: 5px;
@@ -162,6 +181,74 @@ button {
 
 button:hover {
   background-color: #3949ab;
+}
+
+.secondary-btn {
+  background-color: #eceff1;
+  color: #263238;
+}
+
+.secondary-btn:hover {
+  background-color: #cfd8dc;
+}
+
+.button-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.time-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+
+@media (min-width: 560px) {
+  .time-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.advisor-sessions-panel {
+  margin-top: 20px;
+  padding-top: 12px;
+  border-top: 1px dashed #ccc;
+}
+
+.advisor-sessions-panel h4 {
+  margin-bottom: 10px;
+  color: #1a237e;
+}
+
+.advisor-activity-group {
+  margin-bottom: 14px;
+}
+
+.advisor-activity-group h5 {
+  margin-bottom: 6px;
+  color: #0066cc;
+}
+
+.advisor-session-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.session-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.session-actions button {
+  font-size: 13px;
+  padding: 6px 10px;
+}
+
+#session-message {
+  margin-top: 14px;
 }
 
 .message {


### PR DESCRIPTION
## Summary
- add structured activity session model (date, start/end time, optional location)
- add session APIs for list/create/update/delete
- show upcoming sessions in activity cards
- add advisor session management UI for create/edit/delete
- document new endpoints in README

## Validation
- backend compile check passed
- manual API smoke tests passed for:
  - GET /activities
  - POST /advisor/activities/{activity}/sessions
  - PUT /advisor/activities/{activity}/sessions/{id}
  - DELETE /advisor/activities/{activity}/sessions/{id}

## Related Issue
- Implements #12